### PR TITLE
Allow for enum symbols as strings in python2

### DIFF
--- a/src/convert.c
+++ b/src/convert.c
@@ -221,7 +221,7 @@ static int pystring_to_enum(PyObject* obj, avro_value_t* value) {
     int index;
     const char* symbol_name;
     avro_schema_t schema = avro_value_get_schema(value);
-    if (PyUnicode_Check(obj)) {
+    if (_PyUnicode_CheckExact(obj)) {
         symbol_name = PyUnicode_AsUTF8(obj);
     } else if (_PyLong_Check(obj)) {
         symbol_name = avro_schema_enum_get(schema, PyLong_AsLong(obj));

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -76,6 +76,7 @@ class TestEncoder(object):
             assert result == b"\nLarry*"
 
     def test_type_enum(self):
+        # Test Avro enum encoding with quickavro custom Enum type
         Gender = quickavro.Enum("Gender", "F M")
             
         with quickavro.BinaryEncoder() as encoder:
@@ -84,6 +85,18 @@ class TestEncoder(object):
             result = encoder.write(Gender.F)
             assert result == b"\x00"
             result = encoder.write(Gender.M)
+            assert result == b"\x02"
+
+        # Test Avro enum encoding with string symbols matching a schema
+        with quickavro.BinaryEncoder() as encoder:
+            encoder.schema = {
+                "type": "enum",
+                "name": "Gender",
+                "symbols": ["F", "M"]
+            }
+            result = encoder.write("F")
+            assert result == b"\x00"
+            result = encoder.write("M")
             assert result == b"\x02"
 
     def test_type_fixed(self):


### PR DESCRIPTION
Enum encoding should support both the custom enum type and passing in
string symbols that match symbols defined in the schema.  Call the
python2/python3 compatible _PyUnicode_CheckExact macro in order to
enable support for Python2 string symbol passing.  Also add in a unit
test for this.

fixes #2