### PR TITLE
When checking map key, fail if not a Python string

### DIFF
--- a/src/convert.c
+++ b/src/convert.c
@@ -376,7 +376,7 @@ static int validate_map(PyObject* obj, avro_schema_t schema) {
     subschema = avro_schema_map_values(schema);
 
     while (PyDict_Next(obj, &pos, &key, &value)) {
-        if (PyUnicode_CheckExact(key) || validate(value, subschema) < 0) {
+        if (!_PyUnicode_CheckExact(key) || validate(value, subschema) < 0) {
             return -1;
         }
     }

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -113,5 +113,15 @@ class TestEncoder(object):
             result = encoder.write({"age": None})
             assert result == b"\x02"
 
+    def test_type_map(self):
+        with quickavro.BinaryEncoder() as encoder:
+            encoder.schema = {
+                "type": "map",
+                "values": "string"
+            }
+            test_map = {"mykey": "myval"}
+            result = encoder.write(test_map)
+            assert result == b"\x02\nmykey\nmyval\x00"
+
     def test_type_link(self):
         pass


### PR DESCRIPTION
Previously, there was a logic error where a key for an Avro map
was considered invalid if it passed the PyUnicode_CheckExact call.
A valid key should always successfully pass that check, so negate
that check to detect failure.

In addition, only Python3 actually has unicode keys, and Python2 uses
str values.  Use the private _PyUnicode_CheckExact macro in order to
have Python2/Python3 compatibilty.

Add a basic unit test for testing the encoding of the map type.

fixes #3