### PR TITLE
Add support for recursive schema validation

### DIFF
--- a/src/convert.c
+++ b/src/convert.c
@@ -534,6 +534,7 @@ int validate(PyObject* obj, avro_schema_t schema) {
         case AVRO_UNION:
             return validate_union(obj, schema);
         case AVRO_LINK:
+            return validate(obj, avro_schema_link_target(schema));
         default:
             return -1;
     }

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -114,4 +114,16 @@ class TestEncoder(object):
             assert result == b"\x02"
 
     def test_type_link(self):
-        pass
+        with quickavro.BinaryEncoder() as encoder:
+            encoder.schema = {
+                "type": "record",
+                "name": "chainlink",
+                "fields": [
+                    {"name": "linkid", "type": "int"},
+                    {"name": "nextlink", "type": ["null", "chainlink"]}
+                ]
+            }
+
+            chain = {"linkid": 1, "nextlink": {"linkid": 2}}
+            result = encoder.write(chain)
+            assert result == b"\x02\x02\x04\x00"


### PR DESCRIPTION
The AVRO_LINK type is a C API place holder used for dealing with
recursive schemas.  Implement validation for this type, and add in a
unit test.

fixes #4