### PR TITLE
Add support for Avro arrays in union conversion

### DIFF
--- a/src/convert.h
+++ b/src/convert.h
@@ -39,6 +39,7 @@ static const tabledef p2a[] = {
     {"unicode", "string"},
     {"NoneType", "null"},
     {"bool", "boolean"},
+    {"list", "array"},
     {NULL}
 };
 

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -104,14 +104,20 @@ class TestEncoder(object):
                 "type": "record",
                 "name": "test",
                 "fields": [
-                    {"name": "age", "type": ["int", "null"]},
+                    {"name": "ages", "type": [
+                        "int",
+                        "null",
+                        {"type": "array", "items": "int"}
+                    ]},
                 ]
             }
             # encoder.schema = {"type": ["string", "null"]}
-            result = encoder.write({"age": 25})
+            result = encoder.write({"ages": 25})
             assert result == b"\x002"
-            result = encoder.write({"age": None})
+            result = encoder.write({"ages": None})
             assert result == b"\x02"
+            result = encoder.write({"ages": [16, 18, 21]})
+            assert result == b"\x04\x06 $*\x00"
 
     def test_type_link(self):
         pass


### PR DESCRIPTION
This change allows for Avro arrays to be members of a union if the
provided python object is a list.  Also add in a unit test for this
new functionality.

fixes #5