### PR TITLE
Used bytes for Avro Fixed type

### DIFF
--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -88,9 +88,10 @@ class TestEncoder(object):
 
     def test_type_fixed(self):
         with quickavro.BinaryEncoder() as encoder:
-            encoder.schema = {"name": "test", "type": "fixed", "size": 5}
-            result = encoder.write("fixed")
-            assert result == b"fixed"
+            value = b"\x01\x02\x03\x04\x05\x06\x07\x08"
+            encoder.schema = {"name": "test", "type": "fixed", "size": len(value)}
+            result = encoder.write(value)
+            assert result == b"\x01\x02\x03\x04\x05\x06\x07\x08"
 
     def test_type_array(self):
         with quickavro.BinaryEncoder() as encoder:


### PR DESCRIPTION
Instead of accepting python Unicode as the primary representation
of a Fixed type and falling back to bytes, strictly accept bytes
as the fixed type.  Update the function names, logic, and unit test
to reflect this change.

fixes #7