### PR TITLE
Allow for optional enum types

### DIFF
--- a/src/convert.c
+++ b/src/convert.c
@@ -345,7 +345,10 @@ static int validate_array(PyObject* obj, avro_schema_t schema) {
 
 static int validate_enum(PyObject* obj, avro_schema_t schema) {
     const char* symbol_name;
-    if (PyUnicode_Check(obj)) {
+
+    if (obj == Py_None) {
+        return -1;
+    } else if (_PyUnicode_CheckExact(obj)) {
         symbol_name = PyUnicode_AsUTF8(obj);
     } else if (_PyLong_Check(obj)) {
         symbol_name = avro_schema_enum_get(schema, PyLong_AsLong(obj));

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -113,16 +113,27 @@ class TestEncoder(object):
             assert result == b"\x04\ntest1\ntest2\x00"
 
     def test_type_union(self):
+        TextAge = quickavro.Enum("TextAge", "AGE_ONE AGE_TWO")
         with quickavro.BinaryEncoder() as encoder:
             encoder.schema = {
                 "type": "record",
                 "name": "test",
                 "fields": [
-                    {"name": "ages", "type": [
-                        "int",
-                        "null",
-                        {"type": "array", "items": "int"}
-                    ]},
+                    {
+                        "name": "ages",
+                        "type": [
+                            "int",
+                            "null",
+                            {
+                                "type": "array",
+                                "items": "int"
+                            },{
+                                "type": "enum",
+                                "name": "TextAge",
+                                "symbols": ["AGE_ONE", "AGE_TWO"]
+                            }
+                        ]
+                    },
                 ]
             }
             # encoder.schema = {"type": ["string", "null"]}
@@ -132,6 +143,10 @@ class TestEncoder(object):
             assert result == b"\x02"
             result = encoder.write({"ages": [16, 18, 21]})
             assert result == b"\x04\x06 $*\x00"
+            result = encoder.write({"ages": "AGE_ONE"})
+            assert result == b"\x06\x00"
+            result = encoder.write({"ages": TextAge.AGE_TWO})
+            assert result == b"\x06\x02"
 
     def test_type_map(self):
         with quickavro.BinaryEncoder() as encoder:


### PR DESCRIPTION
 * Make sure to call the Python2/Python3 compatible
   _PyUnicode_CheckExact function, which is needed for enums which
   are passed in using a string representation of enum symbol.
 * Check for the None type in validate_enum.  It seems that for
   optional enum types, a None may get passed in, in which case we
   want the check to fail.  I think this occurs based on whichever
   branch of the union the code tries to validate first.

fixes #6