### PR TITLE
Add support for optional Fixed/Bytes in Python3

### DIFF
--- a/src/convert.c
+++ b/src/convert.c
@@ -307,6 +307,8 @@ static int python_to_union(PyObject* obj, avro_value_t* value) {
         branch_index = validate(obj, schema);
     } else if (_PyUnicode_CheckExact(obj)) {
         branch_index = validate(obj, schema);
+    } else if (PyBytes_CheckExact(obj)) {
+        branch_index = validate(obj, schema);
     } else if (_PyLong_Check(obj)) {
         branch_index = validate(obj, schema);
     } else {

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -133,6 +133,29 @@ class TestEncoder(object):
             result = encoder.write({"ages": [16, 18, 21]})
             assert result == b"\x04\x06 $*\x00"
 
+    def test_type_union_fixed(self):
+        with quickavro.BinaryEncoder() as encoder:
+            value = b"\x01\x02\x03\x04\x05\x06\x07\x08"
+            encoder.schema = {
+                "type": "record",
+                "name": "TestRecord",
+                "fields": [
+                    {
+                        "name": "testfield",
+                        "type": [
+                            "null",
+                            {"name": "testfixed", "type": "fixed", "size": len(value)}
+                        ]
+                    }
+                ]
+            }
+            result = encoder.write({"testfield": None})
+            assert result == b"\x00"
+            result = encoder.write({})
+            assert result == b"\x00"
+            result = encoder.write({"testfield": value})
+            assert result == b"\x02\x01\x02\x03\x04\x05\x06\x07\x08"
+
     def test_type_map(self):
         with quickavro.BinaryEncoder() as encoder:
             encoder.schema = {


### PR DESCRIPTION
The python_to_union function needs another manual type check
for PyBytes in order to support Avro Bytes and Fixed types under
Python 3.  This line is not reached under Python 2 in the case of
Bytes and Fixed types due to the check right above.  Add in a new
unit test for this too.

fixes #13