### PR TITLE
Add parentheses to compound conditional macros

### DIFF
--- a/src/compat.h
+++ b/src/compat.h
@@ -45,8 +45,8 @@
   #define PyUnicode_AsUTF8 PyString_AsString
   #define PyNumber_FloorDivide PyNumber_Divide
   #define PyBytes_FromStringAndSize PyString_FromStringAndSize
-  #define _PyLong_Check(ob) PyLong_Check(ob) || PyInt_Check(ob)
-  #define _PyUnicode_CheckExact(ob) PyString_CheckExact(ob) || PyUnicode_CheckExact(ob)
+  #define _PyLong_Check(ob) (PyLong_Check(ob) || PyInt_Check(ob))
+  #define _PyUnicode_CheckExact(ob) (PyString_CheckExact(ob) || PyUnicode_CheckExact(ob))
 
   #define MOD_ERROR_VAL
   #define MOD_SUCCESS_VAL(val)


### PR DESCRIPTION
Macros that define compound conditionals should have the definition
wrapped by parentheses to avoid surprises when calling the macro.

Addresses #16