### PR TITLE
Define a default codec for FileReader

### DIFF
--- a/quickavro/reader.py
+++ b/quickavro/reader.py
@@ -38,7 +38,7 @@ class FileReader(BinaryEncoder):
         header = self.read_header(header_size)
         metadata = header.get('meta')
         self.schema = json.loads(ensure_str(metadata.get('avro.schema')))
-        self.codec = ensure_str(metadata.get('avro.codec'))
+        self.codec = ensure_str(metadata.get('avro.codec', 'null'))
         self.sync_marker = header.get('sync')
 
     def close(self):


### PR DESCRIPTION
Currently, the FileReader class does not handle the case where
an Avro container file does not include the codec.  The Avro spec
requires that the value should default to the 'null' codec when
this happens.  Add in support for this default.

Addresses #25